### PR TITLE
feat: add retry policies and retry reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,44 @@ Documented row statuses:
 `BatchError` values so downstream code can inspect or retry them instead of treating them as silent
 validation failures.
 
+## Retry policies and reports
+
+`job.preview_retry()` lets you inspect retry decisions before you submit a follow-up batch:
+
+```python
+from batchkit import RetryPolicy
+
+
+plan = job.preview_retry(policy=RetryPolicy.execution_only())
+
+print(plan.summary.selected_rows)
+print(plan.summary.skipped_by_reason)
+```
+
+Built-in retry policy helpers:
+
+- `RetryPolicy.all_retryable()` retries all rows currently marked retryable
+- `RetryPolicy.execution_only()` retries only `failed_execution` rows
+- `RetryPolicy.incomplete_only()` retries only `incomplete`, `expired`, and `cancelled` rows
+
+You can also filter by error code:
+
+```python
+policy = RetryPolicy(
+    include_error_codes={"rate_limit_exceeded", "server_error"},
+    exclude_error_codes={"batch_failed"},
+)
+
+retry_job = job.retry_failed(policy=policy)
+```
+
+Each retry job persists:
+
+- the retry policy that was used
+- a summary of selected and skipped rows
+- per-row retry decisions in `retry_report.json`
+- retry lineage in the child manifest so multiple retry attempts remain inspectable
+
 ## What It Handles
 
 - request JSONL generation

--- a/src/batchkit/__init__.py
+++ b/src/batchkit/__init__.py
@@ -9,6 +9,7 @@ from .errors import (
 )
 from .jobs import AsyncBatchJob, BatchJob
 from .results import BatchResults, BatchRow
+from .retry import RetryDecision, RetryPlan, RetryPolicy, RetrySummary
 
 __all__ = [
     "AsyncBatchClient",
@@ -21,5 +22,9 @@ __all__ = [
     "BatchResults",
     "BatchRow",
     "DuplicateCustomIDError",
+    "RetryDecision",
+    "RetryPlan",
+    "RetryPolicy",
+    "RetrySummary",
     "RetryUnavailableError",
 ]

--- a/src/batchkit/jobs.py
+++ b/src/batchkit/jobs.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from .errors import BatchError, BatchNotReadyError, RetryUnavailableError
 from .manifests import read_json, read_jsonl, utc_now_iso, write_json
 from .results import BatchResults, build_results
+from .retry import RetryPlan, RetryPolicy, build_retry_plan
 
 TERMINAL_STATUSES = {"completed", "failed", "expired", "cancelled"}
 
@@ -110,11 +111,39 @@ class BatchJob:
             results = self._apply_schema(results, schema)
         return results
 
-    def retry_failed(self, name: str | None = None) -> BatchJob:
+    def retry_failed(
+        self,
+        name: str | None = None,
+        *,
+        policy: RetryPolicy | None = None,
+    ) -> BatchJob:
+        return self.retry_failed_with_policy(name=name, policy=policy)
+
+    def preview_retry(self, policy: RetryPolicy | None = None) -> RetryPlan:
         results = self.results()
-        retry_records = [row for row in results.rows if row.retryable]
+        lineage_job_ids = self._retry_lineage_for_child()
+        return build_retry_plan(
+            source_job_id=self.id,
+            source_job_name=self.name,
+            lineage_job_ids=lineage_job_ids,
+            results=results,
+            policy=policy,
+        )
+
+    def retry_failed_with_policy(
+        self,
+        *,
+        name: str | None = None,
+        policy: RetryPolicy | None = None,
+    ) -> BatchJob:
+        plan = self.preview_retry(policy=policy)
+        retry_records = plan.selected_rows
         if not retry_records:
-            raise RetryUnavailableError("No retryable rows found")
+            skipped = ", ".join(
+                f"{reason}={count}" for reason, count in plan.summary.skipped_by_reason.items()
+            )
+            detail = f" ({skipped})" if skipped else ""
+            raise RetryUnavailableError(f"No rows matched retry policy{detail}")
         retry_name = name or f"{self.name}-retry"
         request_rows = [row.request_line for row in retry_records]
         request_index = [
@@ -127,17 +156,55 @@ class BatchJob:
             }
             for index, row in enumerate(retry_records)
         ]
-        return cast(
-            BatchJob,
-            self._client._submit_request_rows(
-                name=retry_name,
-                request_rows=request_rows,
-                request_index=request_index,
-                metadata={"retry_of": self.id},
-                parent_job_id=self.id,
-                storage_root=self.storage_dir.parent,
+        return self._finalize_retry_job(
+            plan=plan,
+            child=cast(
+                BatchJob,
+                self._client._submit_request_rows(
+                    name=retry_name,
+                    request_rows=request_rows,
+                    request_index=request_index,
+                    metadata=self._retry_metadata(plan),
+                    parent_job_id=self.id,
+                    storage_root=self.storage_dir.parent,
+                ),
             ),
         )
+
+    def _retry_metadata(self, plan: RetryPlan) -> dict[str, str]:
+        return {
+            "retry_of": self.id,
+            "retry_root": plan.root_job_id,
+            "retry_attempt": str(plan.attempt),
+            "retry_selected": str(plan.summary.selected_rows),
+        }
+
+    def _retry_lineage_for_child(self) -> list[str]:
+        retry_info = self._manifest.get("retry")
+        if not isinstance(retry_info, dict):
+            return [self.id]
+        lineage = retry_info.get("lineage_job_ids")
+        if not isinstance(lineage, list):
+            return [self.id]
+        lineage_ids = [value for value in lineage if isinstance(value, str)]
+        return [*lineage_ids, self.id]
+
+    def _finalize_retry_job(self, *, plan: RetryPlan, child: BatchJob) -> BatchJob:
+        report_path = child.storage_dir / "retry_report.json"
+        write_json(report_path, plan.to_payload())
+        child._manifest["paths"]["retry_report"] = str(report_path)
+        child._manifest["retry"] = {
+            "source_job_id": self.id,
+            "source_job_name": self.name,
+            "root_job_id": plan.root_job_id,
+            "attempt": plan.attempt,
+            "lineage_job_ids": plan.lineage_job_ids,
+            "policy": plan.policy.to_payload(),
+            "summary": plan.summary.to_payload(),
+            "report_path": str(report_path),
+        }
+        write_json(child._manifest_file, child._manifest)
+        return child
 
     def cancel(self) -> BatchJob:
         if not self.batch_id:
@@ -258,11 +325,39 @@ class AsyncBatchJob(BatchJob):
             results = self._apply_schema(results, schema)
         return results
 
-    async def retry_failed(self, name: str | None = None) -> AsyncBatchJob:  # type: ignore[override]
+    async def retry_failed(  # type: ignore[override]
+        self,
+        name: str | None = None,
+        *,
+        policy: RetryPolicy | None = None,
+    ) -> AsyncBatchJob:
+        return await self.retry_failed_with_policy(name=name, policy=policy)
+
+    async def preview_retry(self, policy: RetryPolicy | None = None) -> RetryPlan:  # type: ignore[override]
         results = await self.results()
-        retry_records = [row for row in results.rows if row.retryable]
+        lineage_job_ids = self._retry_lineage_for_child()
+        return build_retry_plan(
+            source_job_id=self.id,
+            source_job_name=self.name,
+            lineage_job_ids=lineage_job_ids,
+            results=results,
+            policy=policy,
+        )
+
+    async def retry_failed_with_policy(  # type: ignore[override]
+        self,
+        *,
+        name: str | None = None,
+        policy: RetryPolicy | None = None,
+    ) -> AsyncBatchJob:
+        plan = await self.preview_retry(policy=policy)
+        retry_records = plan.selected_rows
         if not retry_records:
-            raise RetryUnavailableError("No retryable rows found")
+            skipped = ", ".join(
+                f"{reason}={count}" for reason, count in plan.summary.skipped_by_reason.items()
+            )
+            detail = f" ({skipped})" if skipped else ""
+            raise RetryUnavailableError(f"No rows matched retry policy{detail}")
         retry_name = name or f"{self.name}-retry"
         request_rows = [row.request_line for row in retry_records]
         request_index = [
@@ -275,17 +370,18 @@ class AsyncBatchJob(BatchJob):
             }
             for index, row in enumerate(retry_records)
         ]
-        return cast(
+        child = cast(
             AsyncBatchJob,
             await self._client._submit_request_rows(
                 name=retry_name,
                 request_rows=request_rows,
                 request_index=request_index,
-                metadata={"retry_of": self.id},
+                metadata=self._retry_metadata(plan),
                 parent_job_id=self.id,
                 storage_root=self.storage_dir.parent,
             ),
         )
+        return cast(AsyncBatchJob, self._finalize_retry_job(plan=plan, child=child))
 
     async def cancel(self) -> AsyncBatchJob:  # type: ignore[override]
         if not self.batch_id:

--- a/src/batchkit/jobs.py
+++ b/src/batchkit/jobs.py
@@ -117,7 +117,8 @@ class BatchJob:
         *,
         policy: RetryPolicy | None = None,
     ) -> BatchJob:
-        return self.retry_failed_with_policy(name=name, policy=policy)
+        plan = self.preview_retry(policy=policy)
+        return self._retry_from_plan(plan=plan, name=name)
 
     def preview_retry(self, policy: RetryPolicy | None = None) -> RetryPlan:
         results = self.results()
@@ -130,13 +131,7 @@ class BatchJob:
             policy=policy,
         )
 
-    def retry_failed_with_policy(
-        self,
-        *,
-        name: str | None = None,
-        policy: RetryPolicy | None = None,
-    ) -> BatchJob:
-        plan = self.preview_retry(policy=policy)
+    def _retry_from_plan(self, *, plan: RetryPlan, name: str | None = None) -> BatchJob:
         retry_records = plan.selected_rows
         if not retry_records:
             skipped = ", ".join(
@@ -331,7 +326,8 @@ class AsyncBatchJob(BatchJob):
         *,
         policy: RetryPolicy | None = None,
     ) -> AsyncBatchJob:
-        return await self.retry_failed_with_policy(name=name, policy=policy)
+        plan = await self.preview_retry(policy=policy)
+        return await self._retry_from_plan_async(plan=plan, name=name)
 
     async def preview_retry(self, policy: RetryPolicy | None = None) -> RetryPlan:  # type: ignore[override]
         results = await self.results()
@@ -344,13 +340,12 @@ class AsyncBatchJob(BatchJob):
             policy=policy,
         )
 
-    async def retry_failed_with_policy(  # type: ignore[override]
+    async def _retry_from_plan_async(
         self,
         *,
+        plan: RetryPlan,
         name: str | None = None,
-        policy: RetryPolicy | None = None,
     ) -> AsyncBatchJob:
-        plan = await self.preview_retry(policy=policy)
         retry_records = plan.selected_rows
         if not retry_records:
             skipped = ", ".join(

--- a/src/batchkit/retry.py
+++ b/src/batchkit/retry.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .results import BatchResults, BatchRow
+
+DEFAULT_RETRY_STATUSES = frozenset({"failed_execution", "expired", "cancelled", "incomplete"})
+
+
+@dataclass(frozen=True, slots=True)
+class RetryPolicy:
+    statuses: frozenset[str] = field(default_factory=lambda: DEFAULT_RETRY_STATUSES)
+    include_error_codes: frozenset[str] | None = None
+    exclude_error_codes: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "statuses", frozenset(self.statuses))
+        if self.include_error_codes is not None:
+            object.__setattr__(self, "include_error_codes", frozenset(self.include_error_codes))
+        object.__setattr__(self, "exclude_error_codes", frozenset(self.exclude_error_codes))
+
+    @classmethod
+    def all_retryable(cls) -> RetryPolicy:
+        return cls()
+
+    @classmethod
+    def execution_only(cls) -> RetryPolicy:
+        return cls(statuses=frozenset({"failed_execution"}))
+
+    @classmethod
+    def incomplete_only(cls) -> RetryPolicy:
+        return cls(statuses=frozenset({"incomplete", "expired", "cancelled"}))
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "statuses": sorted(self.statuses),
+            "include_error_codes": (
+                sorted(self.include_error_codes) if self.include_error_codes is not None else None
+            ),
+            "exclude_error_codes": sorted(self.exclude_error_codes),
+        }
+
+
+@dataclass(slots=True)
+class RetryDecision:
+    row: BatchRow
+    selected: bool
+    reason_code: str
+    reason: str
+
+    @property
+    def custom_id(self) -> str:
+        return self.row.custom_id
+
+    @property
+    def status(self) -> str:
+        return self.row.status
+
+    @property
+    def retryable(self) -> bool:
+        return self.row.retryable
+
+    @property
+    def error_code(self) -> str | None:
+        if self.row.error is None:
+            return None
+        return self.row.error.code
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "custom_id": self.custom_id,
+            "status": self.status,
+            "retryable": self.retryable,
+            "selected": self.selected,
+            "reason_code": self.reason_code,
+            "reason": self.reason,
+            "error_code": self.error_code,
+        }
+
+
+@dataclass(slots=True)
+class RetrySummary:
+    total_rows: int
+    selected_rows: int
+    skipped_rows: int
+    selected_by_status: dict[str, int]
+    skipped_by_reason: dict[str, int]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "total_rows": self.total_rows,
+            "selected_rows": self.selected_rows,
+            "skipped_rows": self.skipped_rows,
+            "selected_by_status": dict(self.selected_by_status),
+            "skipped_by_reason": dict(self.skipped_by_reason),
+        }
+
+
+@dataclass(slots=True)
+class RetryPlan:
+    source_job_id: str
+    source_job_name: str
+    root_job_id: str
+    attempt: int
+    lineage_job_ids: list[str]
+    policy: RetryPolicy
+    decisions: list[RetryDecision]
+
+    @property
+    def selected(self) -> list[RetryDecision]:
+        return [decision for decision in self.decisions if decision.selected]
+
+    @property
+    def skipped(self) -> list[RetryDecision]:
+        return [decision for decision in self.decisions if not decision.selected]
+
+    @property
+    def selected_rows(self) -> list[BatchRow]:
+        return [decision.row for decision in self.selected]
+
+    @property
+    def summary(self) -> RetrySummary:
+        selected_by_status = Counter(
+            decision.status for decision in self.selected if decision.status
+        )
+        skipped_by_reason = Counter(decision.reason_code for decision in self.skipped)
+        return RetrySummary(
+            total_rows=len(self.decisions),
+            selected_rows=len(self.selected),
+            skipped_rows=len(self.skipped),
+            selected_by_status=dict(sorted(selected_by_status.items())),
+            skipped_by_reason=dict(sorted(skipped_by_reason.items())),
+        )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "source_job_id": self.source_job_id,
+            "source_job_name": self.source_job_name,
+            "root_job_id": self.root_job_id,
+            "attempt": self.attempt,
+            "lineage_job_ids": list(self.lineage_job_ids),
+            "policy": self.policy.to_payload(),
+            "summary": self.summary.to_payload(),
+            "decisions": [decision.to_payload() for decision in self.decisions],
+        }
+
+
+def build_retry_plan(
+    *,
+    source_job_id: str,
+    source_job_name: str,
+    lineage_job_ids: list[str],
+    results: BatchResults,
+    policy: RetryPolicy | None = None,
+) -> RetryPlan:
+    active_policy = policy or RetryPolicy.all_retryable()
+    decisions = [_build_retry_decision(row=row, policy=active_policy) for row in results.rows]
+    root_job_id = lineage_job_ids[0] if lineage_job_ids else source_job_id
+    return RetryPlan(
+        source_job_id=source_job_id,
+        source_job_name=source_job_name,
+        root_job_id=root_job_id,
+        attempt=len(lineage_job_ids),
+        lineage_job_ids=list(lineage_job_ids),
+        policy=active_policy,
+        decisions=decisions,
+    )
+
+
+def _build_retry_decision(*, row: BatchRow, policy: RetryPolicy) -> RetryDecision:
+    if not row.retryable:
+        return RetryDecision(
+            row=row,
+            selected=False,
+            reason_code="non_retryable",
+            reason="Row is marked non-retryable",
+        )
+
+    if row.status not in policy.statuses:
+        return RetryDecision(
+            row=row,
+            selected=False,
+            reason_code="status_filtered",
+            reason=f"Row status '{row.status}' is excluded by the retry policy",
+        )
+
+    error_code = row.error.code if row.error is not None else None
+    if policy.include_error_codes is not None and error_code not in policy.include_error_codes:
+        return RetryDecision(
+            row=row,
+            selected=False,
+            reason_code="error_code_not_included",
+            reason="Row error code is not included by the retry policy",
+        )
+
+    if error_code is not None and error_code in policy.exclude_error_codes:
+        return RetryDecision(
+            row=row,
+            selected=False,
+            reason_code="error_code_excluded",
+            reason="Row error code is excluded by the retry policy",
+        )
+
+    return RetryDecision(
+        row=row,
+        selected=True,
+        reason_code="selected",
+        reason="Row matched the retry policy",
+    )

--- a/src/batchkit/retry.py
+++ b/src/batchkit/retry.py
@@ -108,6 +108,7 @@ class RetryPlan:
     lineage_job_ids: list[str]
     policy: RetryPolicy
     decisions: list[RetryDecision]
+    _summary: RetrySummary | None = field(default=None, init=False, repr=False)
 
     @property
     def selected(self) -> list[RetryDecision]:
@@ -123,17 +124,21 @@ class RetryPlan:
 
     @property
     def summary(self) -> RetrySummary:
-        selected_by_status = Counter(
-            decision.status for decision in self.selected if decision.status
-        )
-        skipped_by_reason = Counter(decision.reason_code for decision in self.skipped)
-        return RetrySummary(
-            total_rows=len(self.decisions),
-            selected_rows=len(self.selected),
-            skipped_rows=len(self.skipped),
-            selected_by_status=dict(sorted(selected_by_status.items())),
-            skipped_by_reason=dict(sorted(skipped_by_reason.items())),
-        )
+        if self._summary is None:
+            selected = self.selected
+            skipped = self.skipped
+            selected_by_status = Counter(
+                decision.status for decision in selected if decision.status
+            )
+            skipped_by_reason = Counter(decision.reason_code for decision in skipped)
+            self._summary = RetrySummary(
+                total_rows=len(self.decisions),
+                selected_rows=len(selected),
+                skipped_rows=len(skipped),
+                selected_by_status=dict(sorted(selected_by_status.items())),
+                skipped_by_reason=dict(sorted(skipped_by_reason.items())),
+            )
+        return self._summary
 
     def to_payload(self) -> dict[str, Any]:
         return {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,6 +13,7 @@ from batchkit import (
     BatchClient,
     BatchNotReadyError,
     DuplicateCustomIDError,
+    RetryPolicy,
     RetryUnavailableError,
 )
 
@@ -499,6 +500,166 @@ def test_retry_failed_raises_public_retry_error(tmp_path: Path) -> None:
         job.retry_failed()
 
 
+def test_preview_retry_reports_selected_and_skipped_rows(tmp_path: Path) -> None:
+    sdk = FakeSDK(output_payload=_output_rows(), error_payload=_error_rows())
+    client = BatchClient(sdk)
+    job = client.map(
+        name="movies",
+        items=[{"prompt": "a"}, {"prompt": "b"}],
+        model="gpt-4.1-mini",
+        build_request=lambda item: {"input": item["prompt"]},
+        storage_dir=tmp_path / "job",
+    )
+
+    plan = job.preview_retry()
+
+    assert plan.source_job_id == job.id
+    assert plan.root_job_id == job.id
+    assert plan.attempt == 1
+    assert plan.lineage_job_ids == [job.id]
+    assert plan.summary.total_rows == 2
+    assert plan.summary.selected_rows == 1
+    assert plan.summary.skipped_rows == 1
+    assert plan.summary.selected_by_status == {"failed_execution": 1}
+    assert plan.summary.skipped_by_reason == {"non_retryable": 1}
+    assert [decision.custom_id for decision in plan.selected] == ["movies-1"]
+    assert [decision.reason_code for decision in plan.skipped] == ["non_retryable"]
+
+
+def test_preview_retry_can_filter_by_status_and_error_code(tmp_path: Path) -> None:
+    sdk = FakeSDK(output_payload=_output_rows(), error_payload=_error_rows())
+    client = BatchClient(sdk)
+    job = client.map(
+        name="movies",
+        items=[{"prompt": "a"}, {"prompt": "b"}],
+        model="gpt-4.1-mini",
+        build_request=lambda item: {"input": item["prompt"]},
+        storage_dir=tmp_path / "job",
+    )
+
+    filtered_by_code = job.preview_retry(
+        policy=RetryPolicy(include_error_codes={"api_connection_error"})
+    )
+
+    assert filtered_by_code.summary.selected_rows == 0
+    assert filtered_by_code.summary.skipped_by_reason == {
+        "error_code_not_included": 1,
+        "non_retryable": 1,
+    }
+
+    sdk = FakeSDK(output_payload=_output_rows(), error_payload=b"")
+    client = BatchClient(sdk)
+    incomplete_job = client.map(
+        name="movies",
+        items=[{"prompt": "a"}, {"prompt": "b"}],
+        model="gpt-4.1-mini",
+        build_request=lambda item: {"input": item["prompt"]},
+        storage_dir=tmp_path / "incomplete-job",
+    )
+
+    filtered_by_status = incomplete_job.preview_retry(policy=RetryPolicy.execution_only())
+
+    assert filtered_by_status.summary.selected_rows == 0
+    assert filtered_by_status.summary.skipped_by_reason == {
+        "non_retryable": 1,
+        "status_filtered": 1,
+    }
+
+
+def test_preview_retry_handles_invalid_lineage_and_excluded_error_codes(tmp_path: Path) -> None:
+    sdk = FakeSDK(output_payload=_output_rows(), error_payload=_error_rows())
+    client = BatchClient(sdk)
+    job = client.map(
+        name="movies",
+        items=[{"prompt": "a"}, {"prompt": "b"}],
+        model="gpt-4.1-mini",
+        build_request=lambda item: {"input": item["prompt"]},
+        storage_dir=tmp_path / "job",
+    )
+    job._manifest["retry"] = {"lineage_job_ids": "invalid"}
+
+    filtered = job.preview_retry(policy=RetryPolicy.incomplete_only())
+
+    assert filtered.lineage_job_ids == [job.id]
+    assert filtered.summary.skipped_by_reason == {
+        "non_retryable": 1,
+        "status_filtered": 1,
+    }
+
+    excluded = job.preview_retry(policy=RetryPolicy(exclude_error_codes={"rate_limit_exceeded"}))
+    assert excluded.summary.skipped_by_reason == {
+        "error_code_excluded": 1,
+        "non_retryable": 1,
+    }
+
+
+def test_retry_failed_persists_retry_report_and_lineage(tmp_path: Path) -> None:
+    sdk = FakeSDK(output_payload=_output_rows(), error_payload=_error_rows())
+    client = BatchClient(sdk)
+    job = client.map(
+        name="movies",
+        items=[{"prompt": "a"}, {"prompt": "b"}],
+        model="gpt-4.1-mini",
+        build_request=lambda item: {"input": item["prompt"]},
+        storage_dir=tmp_path / "job",
+    )
+
+    retry_job = job.retry_failed(policy=RetryPolicy.execution_only())
+    retry_manifest = json.loads(
+        (retry_job.storage_dir / "manifest.json").read_text(encoding="utf-8")
+    )
+    retry_report = json.loads(
+        (retry_job.storage_dir / "retry_report.json").read_text(encoding="utf-8")
+    )
+
+    assert retry_manifest["retry"]["source_job_id"] == job.id
+    assert retry_manifest["retry"]["root_job_id"] == job.id
+    assert retry_manifest["retry"]["attempt"] == 1
+    assert retry_manifest["retry"]["lineage_job_ids"] == [job.id]
+    assert retry_manifest["retry"]["summary"]["selected_rows"] == 1
+    assert retry_manifest["paths"]["retry_report"].endswith("retry_report.json")
+    assert retry_report["policy"]["statuses"] == ["failed_execution"]
+    assert retry_report["summary"]["selected_rows"] == 1
+    assert sdk.batches.created_with[1]["metadata"] == {
+        "retry_attempt": "1",
+        "retry_of": job.id,
+        "retry_root": job.id,
+        "retry_selected": "1",
+    }
+
+    retry_job_two = retry_job.retry_failed(
+        name="movies-retry-2",
+        policy=RetryPolicy.execution_only(),
+    )
+    retry_manifest_two = json.loads(
+        (retry_job_two.storage_dir / "manifest.json").read_text(encoding="utf-8")
+    )
+
+    assert retry_manifest_two["retry"]["root_job_id"] == job.id
+    assert retry_manifest_two["retry"]["attempt"] == 2
+    assert retry_manifest_two["retry"]["lineage_job_ids"] == [job.id, retry_job.id]
+    assert sdk.batches.created_with[2]["metadata"]["retry_of"] == retry_job.id
+    assert sdk.batches.created_with[2]["metadata"]["retry_root"] == job.id
+
+
+def test_retry_failed_with_filtered_policy_raises_clear_error(tmp_path: Path) -> None:
+    sdk = FakeSDK(output_payload=_output_rows(), error_payload=_error_rows())
+    client = BatchClient(sdk)
+    job = client.map(
+        name="movies",
+        items=[{"prompt": "a"}, {"prompt": "b"}],
+        model="gpt-4.1-mini",
+        build_request=lambda item: {"input": item["prompt"]},
+        storage_dir=tmp_path / "job",
+    )
+
+    with pytest.raises(
+        RetryUnavailableError,
+        match="No rows matched retry policy",
+    ):
+        job.retry_failed(policy=RetryPolicy(include_error_codes={"api_connection_error"}))
+
+
 def test_cancelled_batches_surface_cancelled_rows(tmp_path: Path) -> None:
     sdk = FakeSDK()
     client = BatchClient(sdk)
@@ -683,6 +844,31 @@ async def test_async_results_support_schema_parsing_and_retry_failed(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_async_preview_retry_and_retry_report(tmp_path: Path) -> None:
+    sdk = AsyncFakeSDK(output_payload=_output_rows(), error_payload=_error_rows())
+    client = AsyncBatchClient(sdk)
+    job = await client.map(
+        name="movies",
+        items=[{"prompt": "a"}, {"prompt": "b"}],
+        model="gpt-4.1-mini",
+        build_request=lambda item: {"input": item["prompt"]},
+        storage_dir=tmp_path / "job",
+    )
+
+    plan = await job.preview_retry(policy=RetryPolicy.execution_only())
+    retry_job = await job.retry_failed(policy=RetryPolicy.execution_only())
+    retry_manifest = json.loads(
+        (retry_job.storage_dir / "manifest.json").read_text(encoding="utf-8")
+    )
+
+    assert plan.summary.selected_rows == 1
+    assert plan.summary.selected_by_status == {"failed_execution": 1}
+    assert retry_manifest["retry"]["attempt"] == 1
+    assert retry_manifest["retry"]["lineage_job_ids"] == [job.id]
+    assert retry_manifest["retry"]["policy"]["statuses"] == ["failed_execution"]
+
+
+@pytest.mark.asyncio
 async def test_async_results_raise_when_batch_never_reaches_terminal_state(tmp_path: Path) -> None:
     sdk = AsyncFakeSDK()
 
@@ -808,6 +994,25 @@ async def test_async_retry_failed_raises_public_retry_error(tmp_path: Path) -> N
 
     with pytest.raises(RetryUnavailableError):
         await job.retry_failed()
+
+
+@pytest.mark.asyncio
+async def test_async_retry_failed_with_filtered_policy_raises_clear_error(tmp_path: Path) -> None:
+    sdk = AsyncFakeSDK(output_payload=_output_rows(), error_payload=_error_rows())
+    client = AsyncBatchClient(sdk)
+    job = await client.map(
+        name="movies",
+        items=[{"prompt": "a"}, {"prompt": "b"}],
+        model="gpt-4.1-mini",
+        build_request=lambda item: {"input": item["prompt"]},
+        storage_dir=tmp_path / "job",
+    )
+
+    with pytest.raises(
+        RetryUnavailableError,
+        match="No rows matched retry policy",
+    ):
+        await job.retry_failed(policy=RetryPolicy(include_error_codes={"api_connection_error"}))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This pull request introduces a robust and flexible retry policy system for batch jobs, allowing users to preview and customize which rows will be retried based on status and error codes. It adds new classes and methods for defining, applying, and reporting retry policies, updates the job retry logic to use these policies, and provides comprehensive reporting and lineage tracking for retried jobs. Extensive tests and documentation have also been added to ensure reliability and clarity.

**Retry Policy System and Core Logic:**

- Introduced new classes (`RetryPolicy`, `RetryDecision`, `RetryPlan`, `RetrySummary`) and a builder function in `retry.py` to encapsulate retry logic, including filtering by status and error code, and summarizing retry decisions.
- Updated `BatchJob` and `AsyncBatchJob` in `jobs.py` to support:
  - Custom retry policies for retries via new `policy` argument.
  - `preview_retry()` method to preview which rows would be retried and why.
  - Improved retry lineage tracking and metadata persistence.
  - Detailed retry reports (`retry_report.json`) and manifest updates for each retry attempt. [[1]](diffhunk://#diff-7fdd354e2d498e4da466ae48307a0f6dfad2c0558cd69122319800207e31f86cR11) [[2]](diffhunk://#diff-7fdd354e2d498e4da466ae48307a0f6dfad2c0558cd69122319800207e31f86cL113-R146) [[3]](diffhunk://#diff-7fdd354e2d498e4da466ae48307a0f6dfad2c0558cd69122319800207e31f86cL130-R208) [[4]](diffhunk://#diff-7fdd354e2d498e4da466ae48307a0f6dfad2c0558cd69122319800207e31f86cL261-R360) [[5]](diffhunk://#diff-7fdd354e2d498e4da466ae48307a0f6dfad2c0558cd69122319800207e31f86cL278-R384)

**Public API and Documentation:**

- Exported new retry-related classes in `__init__.py` for public use. [[1]](diffhunk://#diff-da8e5be53654c40b242ea063eaec205ae468f6b4b767e1f3d70fa0229826ecc2R12) [[2]](diffhunk://#diff-da8e5be53654c40b242ea063eaec205ae468f6b4b767e1f3d70fa0229826ecc2R25-R28)
- Added comprehensive documentation to `README.md` explaining retry policies, usage examples, and available helpers.

**Testing:**

- Added extensive tests for retry logic, policy filtering, retry lineage, and error handling in `test_client.py`. These tests ensure correct behavior of retry previewing, policy application, reporting, and manifest updates. [[1]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R16) [[2]](diffhunk://#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110R503-R662)

## What changed

  - add `RetryPolicy`, `RetryPlan`, `RetryDecision`, and `RetrySummary`
  - add `job.preview_retry(...)` / `await job.preview_retry(...)` to inspect retry decisions before submission
  - extend `job.retry_failed(...)` and `await job.retry_failed(...)` with a `policy=` parameter
  - support built-in retry policy presets for all retryable rows, execution-only rows, and incomplete rows
  - support `include_error_codes` / `exclude_error_codes` filtering
  - persist `retry_report.json` for each retry job with per-row selected/skipped decisions
  - persist retry lineage, policy, and summary metadata in the child manifest
  - document retry policies and retry reports in the README

  ## Why this approach

  The current code already reconciles row-level status and error data. The missing piece was a reviewable selection layer between
  `results()` and `retry_failed()`.

  This keeps the retry flow explicit:
  - users can preview the next retry batch before submitting it
  - retry decisions explain why each row was selected or skipped
  - child jobs carry enough manifest/report metadata to inspect multi-attempt retry chains later

  ## Validation

  - `.venv/bin/python -m ruff check .`
  - `.venv/bin/python -m pytest --cov=batchkit --cov-report=term-missing -q`
  - `.venv/bin/python -m mypy src`
  - result: `56 passed`, `100%` coverage
